### PR TITLE
fix tests by adding to extension methods to AINGramModel

### DIFF
--- a/src/LLM-Metrics/AINgramModel.extension.st
+++ b/src/LLM-Metrics/AINgramModel.extension.st
@@ -1,0 +1,13 @@
+Extension { #name : 'AINgramModel' }
+
+{ #category : '*LLM-Metrics' }
+AINgramModel >> asOrderedCollection [
+
+	^ngramCounts asOrderedCollection
+]
+
+{ #category : '*LLM-Metrics' }
+AINgramModel >> isEmpty [
+
+	^ngramCounts isEmpty
+]


### PR DESCRIPTION
tests were not passing because `LLMCandiateSet >> getNgrams:order:`  uses
- `AINGramModelAINGramModel >> #asOrderedCollection`
- `AINGramModel >> #isEmpty`

that are not defined.

I added them as extension of this package